### PR TITLE
Update the bls12-381 repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@ A Native GoLang Implementation for BBS+ Signatures
 
 This library is a port of the [Hyperledger Ursa BBS+](https://github.com/hyperledger/ursa/tree/master/libzmix/bbs) implementation
 
+BLS keypair generation has not been implemented yet.
+
 

--- a/commitment.go
+++ b/commitment.go
@@ -2,7 +2,7 @@ package bbs
 
 import (
 	"crypto/subtle"
-	"github.com/mikelodder7/bls12-381"
+	"github.com/kilic/bls12-381"
 )
 
 // The type for creating commitments to messages that are hidden during issuance.

--- a/generatorG1.go
+++ b/generatorG1.go
@@ -3,7 +3,7 @@ package bbs
 import (
 	"crypto/subtle"
 	"crypto/rand"
-	"github.com/mikelodder7/bls12-381"
+	"github.com/kilic/bls12-381"
 )
 
 // The type for creating commitments to messages that are hidden during issuance.

--- a/generatorG2.go
+++ b/generatorG2.go
@@ -3,7 +3,7 @@ package bbs
 import (
 	"crypto/subtle"
 	"crypto/rand"
-	"github.com/mikelodder7/bls12-381"
+	"github.com/kilic/bls12-381"
 )
 
 // The type for creating commitments to messages that are hidden during issuance.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tosirisuk/go-bbs-signatures
 
-go 1.12
+go 1.13
 
 require (
 	github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/mikelodder7/go-bbs-signatures
+module github.com/tosirisuk/go-bbs-signatures
 
 go 1.12
 
 require (
 	github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1
-	github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526
 	golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mikelodder7/go-bbs-signatures
 go 1.12
 
 require (
+	github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1
 	github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526
 	golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1 h1:fLyvBx6b/VrqcC1KlgTsPdpX3BcwGRWV8P6QfdgOLuw=
+github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
 github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526 h1:RZEAtibpJVsGkS1kOsL6En/4Hx5542PjbImmdSQSDf0=
 github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526/go.mod h1:aaUkv0DevwjI+18IKgH0FsQkd6MgXxUNdVZuU3rueB8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1 h1:fLyvBx6b/VrqcC1KlgTsPdpX3BcwGRWV8P6QfdgOLuw=
 github.com/kilic/bls12-381 v0.0.0-20201104083100-a288617c07f1/go.mod h1:gcwDl9YLyNc3H3wmPXamu+8evD8TYUa6BjTsWnvdn7A=
-github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526 h1:RZEAtibpJVsGkS1kOsL6En/4Hx5542PjbImmdSQSDf0=
-github.com/mikelodder7/bls12-381 v0.0.0-20200708145258-ee2bda426526/go.mod h1:aaUkv0DevwjI+18IKgH0FsQkd6MgXxUNdVZuU3rueB8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0 h1:eIYIE7EC5/Wv5Kbz8bJPaq+TN3kq3W8S+LSm62vM0DY=
 golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/lib.go
+++ b/lib.go
@@ -20,7 +20,7 @@ package bbs
 
 import (
 	"golang.org/x/crypto/blake2b"
-	"github.com/mikelodder7/bls12-381"
+	"github.com/kilic/bls12-381"
 	"hash"
 	"math/big"
 )

--- a/lib.go
+++ b/lib.go
@@ -53,12 +53,12 @@ var (
 )
 
 func hashToG1(data []byte) *bls12381.PointG1 {
-	p1, _ := g1.HashToCurve(newBlake2b, data, dstG1)
+	p1, _ := g1.HashToCurve(data, dstG1)
 	return p1
 }
 
 func hashToG2(data []byte) *bls12381.PointG2 {
-	p2, _ := g2.HashToCurve(newBlake2b, data, dstG2)
+	p2, _ := g2.HashToCurve(data, dstG2)
 	return p2
 }
 

--- a/proofChallenge.go
+++ b/proofChallenge.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	bls12381 "github.com/mikelodder7/bls12-381"
+	bls12381 "github.com/kilic/bls12-381"
 )
 
 type ProofChallenge struct {


### PR DESCRIPTION
1. Change the `bls12-381` repository 
2. Has to Curve functions (`hashToG1` and `hashToG1`) require only two arguments. Three arguments were passed.
